### PR TITLE
Initial commit of townsquare_spy module.

### DIFF
--- a/townsquare_spy/.gitignore
+++ b/townsquare_spy/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+venv

--- a/townsquare_spy/README.md
+++ b/townsquare_spy/README.md
@@ -1,0 +1,25 @@
+# Townsquare Spy
+
+This is a Python module to observe the townsquare app. It is intended to possibly be integrated with the bot, but isn't yet.
+
+## Setup
+
+1. Install a recent version of [Python](https://python.org/).
+1. (Optional) Create a virtualenv to store dependencies. See [Python documentation](https://docs.python.org/3/library/venv.html) for how to do this.
+1. Install requirements. `pip install -r requirements.txt`
+
+## Usage
+
+You can monitor an ongoing game from its URL.
+
+```
+python -m spy "https://clocktower.online/#game"
+```
+
+## Testing
+
+The unit tests can be run by simply invoking `pytest`.
+
+```
+pytest
+```

--- a/townsquare_spy/requirements.txt
+++ b/townsquare_spy/requirements.txt
@@ -1,0 +1,2 @@
+pytest==8.2.1
+websockets==12.0

--- a/townsquare_spy/spy.py
+++ b/townsquare_spy/spy.py
@@ -1,0 +1,491 @@
+import argparse
+import asyncio
+import json
+import json.decoder
+import secrets
+import sys
+import websockets
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+# Used to store the state of a session.
+
+@dataclass
+class Player:
+    id: str = ''
+    name: str = ''
+    pronouns: str = ''
+    is_dead: bool = False
+    is_voteless: bool = False
+    known_role: str = ''
+
+@dataclass
+class Session:
+    log: Callable[[str], None] = lambda x: None
+    players: list[Player] = field(default_factory=list)
+    is_night: bool = False
+    is_vote_history_allowed: bool = False
+    nomination: Optional[list[int]] = None
+    votes: set[int] = field(default_factory=set)
+    is_vote_in_progress: bool = False
+    locked_vote: int = 0
+    marked_player: int = -1
+    fabled: list[str] = field(default_factory=list)
+
+# Fancy (ANSI) formatting!
+# See strip_ansi in spy_test.py for how to remove this.
+
+def player_name(name):
+    return f'\x1b[1;36m{name}\x1b[0m'
+
+def player_pronouns(pronouns):
+    return f'\x1b[0;36m{pronouns}\x1b[0m'
+
+def player_full(player):
+    desc = player_name(player.name)
+    if player.pronouns:
+        desc += f' ({player_pronouns(player.pronouns)})'
+    if player.id:
+        desc += f'\x1b[0;30m [{player.id}]\x1b[0m'
+    if player.known_role:
+        desc += f'\x1b[0;35m <{player.known_role}>\x1b[0m'
+    if player.is_dead:
+        desc += ' 💀'
+        if not player.is_voteless:
+            desc += '🗳️'
+    return desc
+
+def player_seat(name, id):
+    desc = player_name(name)
+    if id:
+        desc += f'\x1b[0;30m [{id}]\x1b[0m'
+    return desc
+
+def night_or_day(is_night):
+    if is_night:
+        return '\x1b[0;34mnight\x1b[0m'
+    return '\x1b[0;33mday\x1b[0m'
+
+# This needs to handle the same messages that src/store/socket.js in bra1n/townsquare does in the "spectator" state.
+# A little decorator is used to register which functions handle which messages.
+
+message_handlers = {}
+
+def townsquare_handler(name):
+    def _decorator(func):
+        message_handlers[name] = func
+        return func
+    return _decorator
+
+@townsquare_handler('bye')
+@townsquare_handler('claim')
+@townsquare_handler('getGamestate')
+@townsquare_handler('ping')
+@townsquare_handler('votingSpeed')
+@townsquare_handler('isVoteWatchingAllowed')  # clocktower.live extension
+def ignore_message(*args):
+    """
+    Ignore all arguments for the received message.
+    """
+    pass
+
+@townsquare_handler('edition')
+def set_edition(session, edition_info):
+    """
+    Changes the script.
+
+    (object):
+        edition (object):
+            id (str): One of the known editions ("tb", "bmr", "snv", "luf") or "custom"
+            name (str, optional): Name of the script (if custom)
+            author (str, optional): Author of the script (if custom)
+        roles (array):
+            id or 0 (str): Character identifier
+            ... remaining keys as numbers in the order they appear in src/store/index.js:
+            ... id, name, image, ability, edition, etc
+    """
+    edition_name = edition_info['edition'].get('name', edition_info['edition']['id'].upper())
+    session.log(f'The script was changed to {edition_name}.')
+    if edition_info.get('roles'):
+        session.log('It contains: ' + ', '.join([r.get('id') or r.get('0') for r in edition_info['roles']]))
+
+@townsquare_handler('gs')
+def receive_game_state(session, state_info):
+    """
+    Receives a full or partial ("lightweight") update of the game state.
+    Currently a lightweight one is never requested by this client; it excludes
+    information aside from the current players' states.
+
+    (object):
+        gamestate (array):
+            name (str): Player's name
+            id (str): Player's ID
+            pronouns (str): Player's preferred pronouns
+            isDead (bool): True if the player is dead
+            isVoteless (bool): True if the player has spent their dead vote
+        isNight (bool): True if the game is in the night phase
+        isVoteHistoryAllowed (bool): True if players may view vote history
+        nomination (null or [int, int]): If a nomination is going on, which player nominated which
+        votes ([bool], optional): By player index, whether the player's hand is up (if a nomination is going on)
+        isVoteInProgress (bool): Whether a vote is currently running
+        lockedVote (int): During a vote, how many votes are locked
+        markedPlayer (int): Which player index, if any, is marked (-1 if none)
+        fabled (array):
+            id (str): Fabled which is in play
+            ... other properties (if custom)
+    """
+    previous_player_names = [p.name for p in session.players]
+    previous_fabled = session.fabled
+
+    if isinstance(state_info.get('gamestate'), list):
+        session.players = [
+            Player(
+                id=p.get("id", ""),
+                name=p.get("name", ""),
+                pronouns=p.get("pronouns", ""),
+                is_dead=p.get("isDead", False),
+                is_voteless=p.get("isVoteless", False),
+                known_role=p.get("roleId", ""),
+            )
+            for p in state_info['gamestate']
+        ]
+    is_lightweight = state_info.get('isLightweight', False)
+    if not is_lightweight:
+        session.is_night = state_info.get('isNight', False)
+        session.is_vote_history_allowed = state_info.get('isVoteHistoryAllowed', False)
+        session.nomination = state_info.get('nomination', None)
+        session.votes = {i for i, v in enumerate(state_info.get('votes', [])) if v}
+        session.is_vote_in_progress = state_info.get('isVoteInProgress', False)
+        session.locked_vote = state_info.get('lockedVote', 0)
+        session.marked_player = state_info.get('markedPlayer', -1)
+        session.fabled = [f['id'] for f in state_info.get('fabled', [])]
+
+    if not is_lightweight:
+        session.log('Players:')
+        for p in session.players:
+            session.log(f'* {player_full(p)}')
+    else:
+        new_player_names = [p.name for p in session.players]
+        for p in new_player_names:
+            if p not in previous_player_names:
+                session.log(f'A seat was added for {player_name(p)}.')
+        for p in previous_player_names:
+            if p not in new_player_names:
+                session.log(f'{player_name(p)} was removed.')
+
+    if not is_lightweight:
+        session.log('Fabled: ' + ', '.join(f'\x1b[0;33m{f}\x1b[0m' for f in session.fabled))
+    else:
+        for f in previous_fabled:
+            if f not in session.fabled:
+                session.log(f'Fabled \x1b[0;33m{f}\x1b[0m was removed.')
+        for f in session.fabled:
+            if f not in previous_fabled:
+                session.log(f'Fabled \x1b[0;33m{f}\x1b[0m was added.')
+
+    if not is_lightweight:
+        session.log(f'It is currently {night_or_day(session.is_night)}.')
+
+    if not is_lightweight and session.marked_player >= 0:
+        session.log(f'{player_name(session.players[session.marked_player].name)} is marked for execution.')
+
+    if not is_lightweight and session.nomination:
+        nominator, nominee = session.nomination
+        session.log(f'{player_name(session.players[nominator].name)} is in the process of nominating {player_name(session.players[nominee].name)}.')
+
+@townsquare_handler('isNight')
+def change_night_phase(session, new_value = None):
+    """
+    Changes from day to night, or night to day.
+
+    new_value (bool): True for night, false for day
+                    Historically, this being absent means to toggle night.
+    """
+    if new_value is None:
+        new_value = not session.is_night
+    session.is_night = new_value
+    session.log(f'It is now {night_or_day(session.is_night)}.')
+
+
+@townsquare_handler('isVoteHistoryAllowed')
+def change_vote_history(session, new_value):
+    """
+    Changes whether players may view the vote history.
+
+    new_value (bool): True for vote history enabled
+    """
+    session.is_vote_history_allowed = new_value
+    session.log('Vote history was turned ' + ('on' if session.is_vote_history_allowed else 'off'))
+    
+@townsquare_handler('clearVoteHistory')
+def clear_vote_history(session, *args):
+    """
+    Clears vote history.
+    """
+    session.log('Vote history was cleared.')
+
+@townsquare_handler('player')
+def update_player(session, update):
+    """
+    Updates a player, such as whether they are seated, pronouns, and life status.
+    These are pushed by the host, so though other spectators observe player
+    requests to change these, the host's updates are sufficient.
+
+    (object):
+        index (int): player to update, by index
+        property (str): property of the player which has changed
+        value (any): new value of the property
+    """
+    index, property, value = update['index'], update['property'], update['value']
+    player = session.players[index]
+    if property == 'id':
+        if not value:
+            session.log(f'{player_seat(player.name, player.id)} left their seat.')
+        else:
+            session.log(f'{player_seat(player.name, value)} claimed their seat.')
+        player.id = value
+    elif property == 'name':
+        session.log(f'{player_name(player.name)} was renamed {player_name(value)}.')
+        player.name = value
+    elif property == 'pronouns':
+        player.pronouns = value
+        if value:
+            session.log(f'{player_name(player.name)} changed their pronouns to {player_pronouns(player.pronouns)}.')
+        else:
+            session.log(f'{player_name(player.name)} cleared their pronouns.')
+    elif property == 'isDead':
+        player.is_dead = value
+        if value:
+            session.log(f'{player_name(player.name)} died.')
+        else:
+            session.log(f'{player_name(player.name)} came back to life.')
+    elif property == 'isVoteless':
+        player.is_voteless = value
+        if value:
+            session.log(f'{player_name(player.name)} spent their dead vote.')
+        elif player.is_dead:
+            session.log(f'{player_name(player.name)}\'s dead vote was restored.')
+    elif property == 'role':
+        if value:
+            player.known_role = value
+            session.log(f'{player_name(player.name)} became a \x1b[0;35m{value}\x1b[0m (traveler).')
+        else:
+            player.known_role = ''
+            session.log(f'{player_name(player.name)} became a resident.')
+
+@townsquare_handler('pronouns')
+def change_pronouns(session, pronoun_info):
+    index, pronouns = pronoun_info
+    player = session.players[index]
+    player.pronouns = pronouns
+    if pronouns:
+        session.log(f'{player_name(player.name)} changed their pronouns to {player_pronouns(player.pronouns)}.')
+    else:
+        session.log(f'{player_name(player.name)} cleared their pronouns.')
+
+@townsquare_handler('nomination')
+def nominate(session, nom = None):
+    """
+    Start or end a nomination.
+
+    (array or null): If an array, it is a [nominator, nominee] pair.
+    """
+    if nom is None:
+        if not session.nomination:
+            pass
+        elif session.locked_vote <= len(session.players):
+            session.log(f'Vote was cancelled.')
+        else:
+            session.log(f'The following players voted: ' +
+                  ', '.join(player_name(session.players[p].name) for p in sorted(session.votes)))
+    else:
+        players = session.players
+        session.log(f'{player_name(players[nom[0]].name)} nominated {player_name(players[nom[1]].name)}.')
+        session.votes = set()
+        session.is_vote_in_progress = False
+        session.locked_vote = 0
+    session.nomination = nom
+
+@townsquare_handler('swap')
+def swap_players(session, indices):
+    """
+    Swap the seats of two players.
+
+    (array): The indices of the two players which were swapped.
+    """
+    players = session.players
+    i, j = indices
+    session.log(f'{player_name(players[i].name)} and {player_name(players[j].name)} swapped seats.')
+    players[i], players[j] = players[j], players[i]
+
+@townsquare_handler('move')
+def move_player(session, indices):
+    """
+    Move the seat of one player.
+
+    (array): The index of the moved player and the new index.
+    """
+    players = session.players
+    i, j = indices
+    session.log(f'{player_name(players[i].name)} moved to seat {j}.')
+    player = players[i]
+    del players[i]
+    players.insert(j, player)
+
+@townsquare_handler('remove')
+def remove_player(session, index):
+    """
+    Remove a seat.
+
+    (int): The index of the removed player.
+    """
+    players = session.players
+    session.log(f'{player_name(players[index].name)} was removed.')
+    del players[index]
+
+@townsquare_handler('marked')
+def mark_player(session, index):
+    """
+    Mark/unmark a player for execution.
+
+    (int): Index of the player who is marked (or -1 to clear)
+    """
+    if index < 0:
+        session.log(f'The execution mark was cleared.')
+    else:
+        session.log(f'{player_name(session.players[index].name)} was marked for execution.')
+    session.marked_player = index
+
+@townsquare_handler('isVoteInProgress')
+def start_end_vote(session, status):
+    """
+    Start/end a vote.
+
+    (bool): Whether a vote is in progress.
+    """
+    session.is_vote_in_progress = status
+
+@townsquare_handler('vote')
+def update_vote(session, info):
+    """
+    Update a player's vote.
+
+    (array):
+        0 (int): Player index
+        1 (any): null or false for no vote, true for vote
+        2 (bool): Whether this is the ST overriding a player vote
+    """
+    if not session.nomination:
+        return
+    index, vote, from_st = info
+    index_locked = (index - 1 - session.nomination[1]) % len(session.players)
+    if from_st or index_locked >= session.locked_vote - 1:
+        if vote:
+            session.votes.add(index)
+        else:
+            session.votes.discard(index)
+
+@townsquare_handler('lock')
+def lock_vote(session, info):
+    """
+    Lock in a player's vote (as observed by the host).
+
+    (array):
+        0 (int): Player index, where the nominated player is 0 and the first player to vote is 1
+        1 (any): null or 0 for no vote, 1 for vote
+    """
+    relative, vote = info
+    session.locked_vote = relative
+    if relative <= 1:
+        return
+    index = (session.nomination[1] + relative - 1) % len(session.players)
+    if vote:
+        session.votes.add(index)
+    else:
+        session.votes.discard(index)
+
+@townsquare_handler('fabled')
+def update_fabled(session, fabled):
+    """
+    Adds or removed fabled characters from play.
+
+    (array):
+        id (str): ID of fabled character
+        ... other properties (if custom)
+    """
+    previous_fabled = session.fabled
+    session.fabled = [f['id'] for f in fabled]
+    for f in previous_fabled:
+        if f not in session.fabled:
+            session.log(f'Fabled \x1b[0;33m{f}\x1b[0m was removed.')
+    for f in session.fabled:
+        if f not in previous_fabled:
+            session.log(f'Fabled \x1b[0;33m{f}\x1b[0m was added.')
+
+def receive(session, m):
+    if not m or not isinstance(m, list) or not isinstance(m[0], str):
+        raise ValueError('malformed message')
+
+    # Message handlers are registered above.
+    handler = message_handlers.get(m[0])
+    if not handler:
+        raise ValueError('unrecognized message type ' + repr(m[0]))
+
+    handler(session, *m[1:])
+
+def random_player_id():
+    return f'spy_{secrets.token_hex(4)}'
+
+# Known servers:
+# https://clocktower.online -> wss://live.clocktower.online:8080/{session}/{player_id}
+# https://clocktower.live -> wss://clocktower.live:8001/{session}/{player_id}
+def interpret_url(game_url, player_id):
+    u = urlparse(game_url)
+    session_name = u.fragment
+    socket_url = None
+    if u.hostname == 'clocktower.online':
+        socket_url = f'wss://live.clocktower.online:8080/{session_name}/{player_id}'
+    elif u.hostname == 'clocktower.live':
+        socket_url = f'wss://clocktower.live:8001/{session_name}/{player_id}'
+    if not session_name or not socket_url:
+        raise ValueError('unknown game URL', game_url)
+    return (socket_url, f'{u.scheme}://{u.netloc}')
+
+async def connect_to_session(socket_url, origin, player_id):
+    async with websockets.connect(socket_url, origin=origin) as ws:
+        await ws.send(json.dumps(["direct", {"host": ["getGamestate", player_id]}]))
+        while True:
+            try:
+                m = json.loads(await ws.recv())
+            except json.decoder.JSONDecodeError:
+                continue
+            yield m
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('url')
+    args = parser.parse_args()
+
+    def print_ts(message):
+        ts = datetime.now(timezone.utc).strftime('\x1b[0;30m[%Y-%m-%d %H:%M:%S %Z]\x1b[0m')
+        print(ts, message)
+
+    player_id = random_player_id()
+    socket_url, app_origin = interpret_url(args.url, player_id)
+    session = Session()
+    session.log = print_ts
+
+    socket = connect_to_session(socket_url, origin=app_origin, player_id=player_id)
+    async for m in socket:
+        try:
+            receive(session, m)
+        except Exception as e:
+            print('While processing', m, file=sys.stderr)
+            raise
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/townsquare_spy/spy_test.py
+++ b/townsquare_spy/spy_test.py
@@ -1,0 +1,635 @@
+"""
+Unit tests for the game logic.
+
+This is isolated from the websocket client by using pre-canned messages.
+"""
+
+import pytest
+import re
+
+from spy import *
+
+def strip_ansi(s):
+    return re.sub(r'\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]', '', s)
+
+def simulated_session():
+    output = []
+    session = Session()
+    session.log = lambda message: output.append(strip_ansi(message))
+    return (session, output)
+
+def any_line_matches(output, pattern):
+    return any(re.search(pattern, strip_ansi(l)) for l in output)
+
+def basic_gs(player_count=8):
+    player_names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango"][:player_count]
+    return dict(
+        gamestate=[
+            dict(name=name,
+                 id=f'PlayerID{idx:02}',
+                 isDead=False,
+                 isVoteless=False,
+                 pronouns="")
+            for idx, name in enumerate(player_names)
+        ],
+        isNight=False,
+        isVoteHistoryAllowed=True,
+        nomination=False,
+        votingSpeed=1000,
+        lockedVote=0,
+        isVoteInProgress=False,
+        markedPlayer=-1,
+        fabled=[]
+    )
+
+def test_shows_edition():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    assert any_line_matches(output, r'script.*TB'), "expected to see script change"
+
+def test_shows_edition_change():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["edition", {"edition": {"id": "bmr"}}])
+    assert any_line_matches(output, r'script.*BMR'), "expected to see script change"
+
+def test_shows_custom_edition():
+    session, output = simulated_session()
+    custom_roles = [
+        dict(id=id)
+        for id in ["clockmaker", "investigator", "empath", "chambermaid", "artist", "sage", "drunk", "klutz", "scarlet_woman", "baron", "imp"]
+    ]
+    custom_edition = dict(id="custom",
+                          name="No Greater Joy",
+                          author="Steven Medway")
+    receive(session, ["edition", {"edition": custom_edition, "roles": custom_roles}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    assert any_line_matches(output, r'script.*No Greater Joy'), "expected to see script change"
+    assert any_line_matches(output, r'chambermaid'), "expected to see character list"
+
+def test_shows_homebrew_edition():
+    session, output = simulated_session()
+    custom_roles = [
+        dict(id="villager",
+             name="Villager",
+             edition="example",
+             team="townsfolk",
+             ability="You have no ability."),
+        dict(id="werewolf",
+             name="Werewolf",
+             edition="example",
+             team="demon",
+             ability="Each night*, choose a player: they die.",
+             otherNight=10,
+             otherNightReminder="The Werewolf chooses a player. :reminder: They die.",
+             reminders=["Dead"])
+    ]
+    custom_edition = dict(id="custom", name="Werewolf", author="")
+    receive(session, ["edition", {"edition": custom_edition, "roles": custom_roles}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    assert any_line_matches(output, r'script.*Werewolf'), "expected to see script change"
+    assert any_line_matches(output, r'villager'), "expected to see character list"
+
+def test_shows_player_names_and_ids():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    assert session.players[5].id == 'PlayerID05'
+    assert session.players[5].name == 'Foxtrot'
+    assert any_line_matches(output, r'Foxtrot')
+    assert any_line_matches(output, r'PlayerID05')
+
+def test_shows_player_starting_life():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["gamestate"][0]["isDead"] = True
+    gs["gamestate"][1]["isDead"] = True
+    gs["gamestate"][1]["isVoteless"] = True
+    receive(session, ["gs", gs])
+    assert session.players[0].is_dead
+    assert not session.players[0].is_voteless
+    assert any_line_matches(output, "Alpha.*💀")
+    assert any_line_matches(output, "Alpha.*🗳")
+    assert session.players[1].is_dead
+    assert session.players[1].is_voteless
+    assert any_line_matches(output, "Bravo.*💀")
+    assert not any_line_matches(output, "Bravo.*🗳")
+    assert not session.players[2].is_dead
+    assert not session.players[2].is_voteless
+    assert not any_line_matches(output, "Charlie.*💀")
+    assert not any_line_matches(output, "Charlie.*🗳")
+
+def test_shows_starting_traveler():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["gamestate"][3]["roleId"] = "scapegoat"
+    receive(session, ["gs", gs])
+    assert session.players[3].name == 'Delta'
+    assert session.players[3].known_role == 'scapegoat'
+    assert any_line_matches(output, r'Delta.*scapegoat')
+
+def test_shows_starting_fabled():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["fabled"] = [{"id": "hellslibrarian"}]
+    receive(session, ["gs", gs])
+    assert session.fabled == ["hellslibrarian"]
+    assert any_line_matches(output, r'hellslibrarian')
+
+def test_shows_starting_day():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["isNight"] = False
+    receive(session, ["gs", gs])
+    assert session.is_night == False
+    assert any_line_matches(output, r'It is currently day.')
+
+def test_shows_starting_night():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["isNight"] = True
+    receive(session, ["gs", gs])
+    assert session.is_night == True
+    assert any_line_matches(output, r'It is currently night.')
+
+def test_shows_starting_execution_mark():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["markedPlayer"] = 4
+    receive(session, ["gs", gs])
+    assert any_line_matches(output, r'Echo.*marked')
+
+# In practice, adding a player causes a lightweight update.
+def test_add_player_lightweight():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=1)
+    player = gs["gamestate"].pop()
+    player["id"] = ""
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["gs", {"gamestate": [player], "isLightweight": True}])
+    assert session.players[0].id == ""
+    assert session.players[0].name == "Alpha"
+    assert any_line_matches(output, r'seat.*added.*Alpha')
+
+# In practice, removing a player causes a remove message.
+def test_remove_player_lightweight():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=1)
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["remove", 0])
+    assert len(session.players) == 0
+    assert any_line_matches(output, r'Alpha.*removed')
+
+def test_add_fabled():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["fabled", [{"id": "buddhist"}]])
+    assert session.fabled == ["buddhist"]
+    assert any_line_matches(output, r'buddhist.*added')
+
+def test_remove_fabled():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["fabled"] = [{"id": "angel"}]
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["fabled", []])
+    assert session.fabled == []
+    assert any_line_matches(output, r'angel.*removed')
+
+def test_day_night():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["isNight", True])
+    assert session.is_night
+    assert any_line_matches(output, r'It is now night')
+    output.clear()
+    receive(session, ["isNight", False])
+    assert not session.is_night
+    assert any_line_matches(output, r'It is now day')
+
+def test_vote_history():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["isVoteHistoryAllowed", False])
+    assert not session.is_vote_history_allowed
+    assert any_line_matches(output, r'Vote history.*off')
+    output.clear()
+    receive(session, ["isVoteHistoryAllowed", True])
+    assert session.is_vote_history_allowed
+    assert any_line_matches(output, r'Vote history.*on')
+    output.clear()
+    receive(session, ["clearVoteHistory", None])
+    assert any_line_matches(output, r'Vote history.*cleared')
+
+def test_rename_player():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["player", dict(index=2, property="name", value="Charles")])
+    receive(session, ["pronouns", [2, "he/him"]])
+    assert session.players[2].name == "Charles"
+    assert session.players[2].pronouns == "he/him"
+    assert any_line_matches(output, r'Charlie.*renamed.*Charles')
+    assert any_line_matches(output, r'Charles.*he/him')
+
+def test_death_resurrection():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["player", dict(index=1, property="isDead", value=True)])
+    assert session.players[1].is_dead
+    assert any_line_matches(output, r'Bravo died')
+    output.clear()
+    receive(session, ["player", dict(index=1, property="isDead", value=False)])
+    assert not session.players[1].is_dead
+    assert any_line_matches(output, r'Bravo came back to life')
+
+def test_dead_vote():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    receive(session, ["player", dict(index=1, property="isDead", value=True)])
+    output.clear()
+    receive(session, ["player", dict(index=1, property="isVoteless", value=True)])
+    assert session.players[1].is_voteless
+    assert any_line_matches(output, r'Bravo spent.*dead vote')
+    output.clear()
+    receive(session, ["player", dict(index=1, property="isVoteless", value=False)])
+    receive(session, ["player", dict(index=1, property="isDead", value=False)])
+    assert not session.players[1].is_voteless
+    assert any_line_matches(output, r'Bravo.*dead vote.*restored')
+
+def test_toggle_traveler():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["player", dict(index=6, property="role", value="beggar")])
+    assert session.players[6].known_role == "beggar"
+    assert any_line_matches(output, "became.*beggar")
+    output.clear()
+    receive(session, ["player", dict(index=6, property="role", value="")])
+    assert not session.players[6].known_role
+    assert any_line_matches(output, "became.*resident")
+
+def test_mark_for_execution():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["marked", 6])
+    assert session.marked_player == 6
+    assert any_line_matches(output, "Golf.*marked")
+    output.clear()
+    receive(session, ["marked", -1])
+    assert session.marked_player == -1
+    assert any_line_matches(output, "mark.*cleared")
+
+def test_nominate_and_cancel():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", [4, 5]])
+    assert session.nomination == [4, 5]
+    assert any_line_matches(output, "Echo nominated Foxtrot")
+    output.clear()
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    assert not session.nomination
+    assert any_line_matches(output, "cancelled")
+
+def test_nominate_and_cancel_with_running_vote():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", [0, 0]])
+    assert session.nomination == [0, 0]
+    assert any_line_matches(output, "Alpha nominated Alpha")
+    output.clear()
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, 1]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    assert not session.nomination
+    assert any_line_matches(output, "cancelled")
+
+def test_complete_vote():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", [0, 0]])
+    assert session.nomination == [0, 0]
+    assert any_line_matches(output, "Alpha nominated Alpha")
+    output.clear()
+    receive(session, ["vote", [1, 1, False]])
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, 1]])
+    receive(session, ["vote", [3, 1, False]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["vote", [3, 0, False]])
+    receive(session, ["lock", [4, 0]])
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, None]])
+    receive(session, ["lock", [7, None]])
+    receive(session, ["lock", [8, None]])
+    receive(session, ["lock", [9, None]])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    assert not session.nomination
+    assert any_line_matches(output, "voted:.*Bravo")
+    assert not any_line_matches(output, "voted:.*Charlie")
+    assert not any_line_matches(output, "voted:.*Delta")
+    assert not any_line_matches(output, "cancelled")
+
+def test_two_votes_one_nom():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=5)
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", [0, 0]])
+    assert session.nomination == [0, 0]
+    assert any_line_matches(output, "Alpha nominated Alpha")
+    output.clear()
+    # First vote
+    receive(session, ["vote", [1, 1, False]])
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, 1]])
+    receive(session, ["vote", [3, 1, False]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["vote", [3, 0, False]])
+    receive(session, ["lock", [4, 0]])
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, None]])
+    receive(session, ["isVoteInProgress", False])
+    # ST ran the vote again
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["vote", [1, 0, False]])
+    receive(session, ["vote", [3, 1, False]])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, 0]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["lock", [4, 1]])
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, None]])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    # Only the last vote counts
+    assert not session.nomination
+    assert not any_line_matches(output, "voted:.*Bravo")
+    assert any_line_matches(output, "voted:.*Delta")
+
+def test_join_during_nomination():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=5)
+    gs["nomination"] = [1, 0]
+    receive(session, ["gs", gs])
+    assert session.nomination == [1, 0]
+    assert any_line_matches(output, "Bravo.*nom.*Alpha")
+    output.clear()
+    receive(session, ["vote", [1, 1, False]])
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, 1]])
+    receive(session, ["vote", [3, 1, False]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["vote", [3, 0, False]])
+    receive(session, ["lock", [4, 0]])
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, None]])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    assert not session.nomination
+    assert any_line_matches(output, "voted:.*Bravo")
+
+def test_join_before_vote():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=5)
+    gs["nomination"] = [0, 0]
+    gs["isVoteInProgress"] = True
+    gs["lockedVote"] = 0
+    gs["votes"] = []
+    receive(session, ["gs", gs])
+    assert session.nomination == [0, 0]
+    assert any_line_matches(output, "Alpha.*nom.*Alpha")
+    output.clear()
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, None]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["lock", [4, None]])
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, None]])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    assert not session.nomination
+    assert any_line_matches(output, r'voted:\s*$')
+
+def test_join_during_vote():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=8)
+    gs["nomination"] = [0, 0]
+    gs["isVoteInProgress"] = True
+    gs["lockedVote"] = 4
+    gs["votes"] = [None, 0, None, 1]
+    receive(session, ["gs", gs])
+    assert session.nomination == [0, 0]
+    assert any_line_matches(output, "Alpha.*nom.*Alpha")
+    output.clear()
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, None]])
+    receive(session, ["vote", [5, 1, False]])
+    receive(session, ["lock", [7, 1]])
+    receive(session, ["lock", [8, None]])
+    receive(session, ["lock", [9, None]])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", None])
+    assert not session.nomination
+    assert any_line_matches(output, "voted:.*Delta")
+    assert any_line_matches(output, "voted:.*Golf")
+
+def test_swap_seats():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["swap", [0, 1]])
+    assert session.players[0].name == "Bravo"
+    assert session.players[0].id == "PlayerID01"
+    assert session.players[1].name == "Alpha"
+    assert session.players[1].id == "PlayerID00"
+    assert any_line_matches(output, "Alpha.*swapped")
+    assert any_line_matches(output, "Bravo.*swapped")
+
+def test_move_seats():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=8)
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["move", [1, 4]])
+    assert [(p.name, p.id) for p in session.players] == \
+        [("Alpha", "PlayerID00"),
+         ("Charlie", "PlayerID02"),
+         ("Delta", "PlayerID03"),
+         ("Echo", "PlayerID04"),
+         ("Bravo", "PlayerID01"),
+         ("Foxtrot", "PlayerID05"),
+         ("Golf", "PlayerID06"),
+         ("Hotel", "PlayerID07")]
+    assert any_line_matches(output, "Bravo.*moved.*4")
+    output.clear()
+    receive(session, ["move", [4, 1]])
+    assert [p.name for p in session.players] == \
+        ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel"]
+    assert any_line_matches(output, "Bravo.*moved.*1")
+
+def test_take_vacate_retake_seat():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    gs["gamestate"][0]["id"] = ""
+    gs["gamestate"][1]["id"] = ""
+    receive(session, ["gs", gs])
+    assert not any_line_matches(output, "PlayerID00")
+    assert any_line_matches(output, "PlayerID02")
+    output.clear()
+    # This is signaled multiple ways; the one that townsquare
+    # observes seems to be "player".
+    # Here a player takes a seat, then vacates it and takes another.
+    # We want to be sure the audit log shows these were in fact
+    # the same client.
+    receive(session, ["claim", [0, "PlayerID00"]])
+    receive(session, ["player", dict(index=0, property="id", value="PlayerID00")])
+    assert session.players[0].id == "PlayerID00"
+    assert any_line_matches(output, "Alpha.*PlayerID00.*claimed")
+    output.clear()
+    receive(session, ["claim", [-1, "PlayerID00"]])
+    receive(session, ["player", dict(index=0, property="id", value="")])
+    assert session.players[0].id == ""
+    assert any_line_matches(output, "Alpha.*PlayerID00.*left")
+    output.clear()
+    receive(session, ["claim", [1, "PlayerID00"]])
+    receive(session, ["player", dict(index=1, property="id", value="PlayerID00")])
+    assert session.players[1].id == "PlayerID00"
+    assert any_line_matches(output, "Bravo.*PlayerID00.*claimed")
+
+def test_ignore_ping():
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    # If you're curious, this is [user count, "latency"]
+    receive(session, ["ping", [9, "69"]])
+    receive(session, ["ping", [9, "420"]])
+    receive(session, ["ping", [9, "47"]])
+
+def test_organ_grinder_extension():
+    # clocktower.live extension for Organ Grinder
+    # No special handling really, but shouldn't break.
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs()
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["isVoteWatchingAllowed", False])
+    receive(session, ["nomination", [0, 0]])
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [9, None]])
+    receive(session, ["nomination", None])
+    assert any_line_matches(output, r'voted:\s*$')
+
+def test_banshee_extension():
+    # clocktower.live extension for Banshee
+    # No special handling really aside from not breaking on a 2 vote.
+    session, output = simulated_session()
+    receive(session, ["edition", {"edition": {"id": "tb"}}])
+    gs = basic_gs(player_count=5)
+    receive(session, ["gs", gs])
+    output.clear()
+    receive(session, ["player", dict(index=0, property="hasTwoVotes", value=True)])
+    receive(session, ["votingSpeed", 1000])
+    receive(session, ["nomination", [0, 0]])
+    assert session.nomination == [0, 0]
+    assert any_line_matches(output, "Alpha nominated Alpha")
+    output.clear()
+    receive(session, ["vote", [0, 2, False]])
+    receive(session, ["lock", [0, None]])
+    receive(session, ["isVoteInProgress", True])
+    receive(session, ["lock", [1, None]])
+    receive(session, ["lock", [2, None]])
+    receive(session, ["lock", [3, None]])
+    receive(session, ["lock", [4, None]])
+    receive(session, ["lock", [5, None]])
+    receive(session, ["lock", [6, 2]])
+    receive(session, ["isVoteInProgress", False])
+    receive(session, ["nomination", None])
+    assert any_line_matches(output, r'voted.*Alpha$')


### PR DESCRIPTION
Fairly basic and not entirely well-documented, but seems to work and includes tests. Can also be run as main to provide a simple and practical way of testing it on actual running games.

In the future, this could be linked to the bot to allow it to start monitoring games which are linked to, and gathering information for auditing or possibly certain statistics (but noting that the townsquare tool doesn't provide all the info one might want, and isn't an altogether secure system against abuse).