### PR TITLE
Restrict application commands to known guilds only.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # You'll need to get a token from the Discord developer site.
 DISCORD_TOKEN="your private token here"
 
+# These are the guild IDs (comma-separated) from which commands are accepted.
+# For some commands, accepting them outside the guilds (servers) intended
+# would allow bypassing access control.
+# They can be found by right-clicking the server and choosing "Copy Server ID".
+# If that option isn't available, enable Developer Mode in the Discord settings.
+GUILDS=569683781800296501
+
 # These are the channels actually in use on Unofficial.
 # Replace these when testing on another server.
 # They can be found by right-clicking the channel and choosing "Copy Channel ID".

--- a/Dot 3 Github.py
+++ b/Dot 3 Github.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 intents = nextcord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="!", intents=intents)
+bot = commands.Bot(command_prefix="!", intents=intents, default_guild_ids=[int(id) for id in os.environ["GUILDS"].split(",")])
 
 # File paths in the same directory as the script
 livequeue_file_path = os.path.join(os.path.dirname(__file__), "Livequeue.json")


### PR DESCRIPTION
This prevents application commands from being used in DMs or on other guilds, which otherwise bypasses access control in server settings.

This could still be overridden for individual commands if needed.